### PR TITLE
Update the usb module to not break osx install

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",
     "temp": "~0.6.0",
-    "usb": "1.1.0"
+    "usb": "^1.1.0"
   },
   "devDependencies": {
     "tap": "~0.4.8",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",
     "temp": "~0.6.0",
-    "usb": "^1.0.6"
+    "usb": "1.1.0"
   },
   "devDependencies": {
     "tap": "~0.4.8",


### PR DESCRIPTION
Used a way old version of the usb module which didn't install with OSX El Cap. Tested with blinky and works fine with update.