### PR TITLE
Update usb package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",
     "temp": "~0.6.0",
-    "usb": "^1.0.6"
+    "usb": "^1.1.2"
   },
   "devDependencies": {
     "tap": "~0.4.8",


### PR DESCRIPTION
Updates the usb package to version 1.1.2, which uses a newer version of node-pre-gyp to fix binary install on OSX and now has binary packages for newer versions of node.

I successfully tested install on OSX with node 4.4 and 5.2, both with npm 2 & 3.

This would supersede #190, since newer versions of usb have been published since that PR was opened.